### PR TITLE
build: adding starts with 'v' check for build tags

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -222,6 +222,7 @@ subprojects {
 }
 
 fun getAuditorVersion(): String {
-    val version = System.getenv().getOrDefault("AUDITOR_VERSION", "0.0.1")
-    return if (gradle.startParameter.taskNames.any { it.contains("Snapshot") }) version.plus("-SNAPSHOT") else version
+    val version = System.getenv().getOrDefault("AUDITOR_VERSION", "v0.0.1")
+    val finalVersion = if (version.startsWith('v')) version.drop(1) else version
+    return if (gradle.startParameter.taskNames.any { it.contains("Snapshot") }) finalVersion.plus("-SNAPSHOT") else finalVersion
 }


### PR DESCRIPTION
Adding starts with 'v' check for build tags then removing the 'v' character and setting to AUDITOR_VERSION